### PR TITLE
Added support for segments

### DIFF
--- a/elf/elf.cc
+++ b/elf/elf.cc
@@ -45,9 +45,10 @@ struct elf::impl
         const shared_ptr<loader> l;
         Ehdr<> hdr;
         vector<section> sections;
-        //vector<segment> segments;
+        vector<segment> segments;
 
         section invalid_section;
+        segment invalid_segment;
 };
 
 elf::elf(const std::shared_ptr<loader> &l)
@@ -87,6 +88,14 @@ elf::elf(const std::shared_ptr<loader> &l)
         if (m->hdr.shnum && m->hdr.shstrndx >= m->hdr.shnum)
                 throw format_error("bad section name string table index");
 
+        // Load segments
+        const void *seg_data = l->load(m->hdr.phoff,
+                                       m->hdr.phentsize * m->hdr.phnum);
+        for (unsigned i = 0; i < m->hdr.phnum; i++) {
+                const void *seg = ((const char*)seg_data) + i * m->hdr.phentsize;
+                m->segments.push_back(segment(*this, seg));
+        }
+
         // Load sections
         const void *sec_data = l->load(m->hdr.shoff,
                                        m->hdr.shentsize * m->hdr.shnum);
@@ -117,6 +126,12 @@ elf::sections() const
         return m->sections;
 }
 
+const std::vector<segment> &
+elf::segments() const
+{
+        return m->segments;
+}
+
 const section &
 elf::get_section(const std::string &name) const
 {
@@ -132,6 +147,57 @@ elf::get_section(unsigned index) const
         if (index >= sections().size())
                 return m->invalid_section;
         return sections().at(index);
+}
+
+const segment&
+elf::get_segment(unsigned index) const
+{
+        if (index >= segments().size())
+                return m->invalid_segment;
+        return segments().at(index);
+}
+
+//////////////////////////////////////////////////////////////////
+// class segment
+//
+
+struct segment::impl {
+        impl(const elf &f)
+                : f(f) { }
+
+        const elf f;
+        Phdr<> hdr;
+        //  const char *name;
+        //  size_t name_len;
+        const void *data;
+};
+
+segment::segment(const elf &f, const void *hdr)
+    : m(make_shared<impl>(f)) {
+        canon_hdr(&m->hdr, hdr, f.get_hdr().ei_class, f.get_hdr().ei_data);
+}
+
+const Phdr<> &
+segment::get_hdr() const {
+        return m->hdr;
+}
+
+const void *
+segment::data() const {
+        if (!m->data)
+                m->data = m->f.get_loader()->load(m->hdr.offset,
+                                                  m->hdr.filesz);
+        return m->data;
+}
+
+size_t
+segment::file_size() const {
+        return m->hdr.filesz;
+}
+
+size_t
+segment::mem_size() const {
+        return m->hdr.memsz;
 }
 
 //////////////////////////////////////////////////////////////////

--- a/elf/elf.cc
+++ b/elf/elf.cc
@@ -20,6 +20,7 @@ void canon_hdr(Hdr<Elf64, byte_order::native> *out, const void *data,
                         out->from(*(Hdr<Elf32, byte_order::msb>*)data);
                         break;
                 }
+                break;
         case elfclass::_64:
                 switch (ei_data) {
                 case elfdata::lsb:

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,6 +1,7 @@
 *.o
 .*.d
 dump-sections
+dump-segments
 dump-syms
 dump-lines
 dump-tree

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,7 +3,7 @@ override CXXFLAGS+=-std=c++0x -Wall
 
 CLEAN :=
 
-all: dump-sections dump-syms dump-tree dump-lines find-pc
+all: dump-sections dump-segments dump-syms dump-tree dump-lines find-pc
 
 # Find libs
 export PKG_CONFIG_PATH+=:../elf:../dwarf
@@ -17,6 +17,10 @@ CPPFLAGS+=-MD -MP -MF .$@.d
 dump-sections: dump-sections.o
 	$(LINK.cc) $^ $(LOADLIBES) $(LDLIBS) -o $@
 CLEAN += dump-sections dump-sections.o
+
+dump-segments: dump-segments.o
+	$(LINK.cc) $^ $(LOADLIBES) $(LDLIBS) -o $@
+CLEAN += dump-segments dump-segments.o
 
 dump-syms: dump-syms.o
 	$(LINK.cc) $^ $(LOADLIBES) $(LDLIBS) -o $@

--- a/examples/dump-segments.cc
+++ b/examples/dump-segments.cc
@@ -1,0 +1,37 @@
+#include "elf++.hh"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int main(int argc, char **argv)
+{
+        if (argc != 2) {
+                fprintf(stderr, "usage: %s elf-file\n", argv[0]);
+                return 2;
+        }
+
+        int fd = open(argv[1], O_RDONLY);
+        if (fd < 0) {
+                fprintf(stderr, "%s: %s\n", argv[1], strerror(errno));
+                return 1;
+        }
+
+        elf::elf f(elf::create_mmap_loader(fd));
+        printf("  %-16s  %-16s   %-16s   %s\n",
+                "Type", "Offset", "VirtAddr", "PhysAddr");
+        printf("  %-16s  %-16s   %-16s  %6s %5s\n",
+                " ", "FileSiz", "MemSiz", "Flags", "Align");
+        for (auto &seg : f.segments()) {
+                auto &hdr = seg.get_hdr();
+                printf("   %-16s 0x%016lx 0x%016lx 0x%016lx\n",
+                        to_string(hdr.type).c_str(), (unsigned long)hdr.offset,
+                        (unsigned long)hdr.vaddr, (unsigned long)hdr.paddr);
+                printf("   %-16s 0x%016lx 0x%016lx %-5s %-5lx\n", "",
+                        (unsigned long)hdr.filesz, (unsigned long)hdr.memsz,
+                        to_string(hdr.flags).c_str(), (unsigned long)hdr.align);
+        }
+
+        return 0;
+}
+


### PR DESCRIPTION
I've added support for reading program header segments. An example **dump-segments.cc** has been included to demonstrate the basic functionality.

Additionally, I've fixed a little bug in parsing ELF32 headers in function **canon_hdr**. I encountered the bug while reading ARM executables.