### PR TITLE
Build with -fPIC so libelfin can be used in shared libraries.

### DIFF
--- a/dwarf/Makefile
+++ b/dwarf/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS+=-g -O2 -Werror
-override CXXFLAGS+=-std=c++0x -Wall
+override CXXFLAGS+=-std=c++0x -Wall -fPIC
 
 all: libdwarf++.a libdwarf++.pc
 

--- a/elf/Makefile
+++ b/elf/Makefile
@@ -1,5 +1,5 @@
 CXXFLAGS+=-g -O2 -Werror
-override CXXFLAGS+=-std=c++0x -Wall
+override CXXFLAGS+=-std=c++0x -Wall -fPIC
 
 all: libelf++.a libelf++.pc
 


### PR DESCRIPTION
Building libelfin with `-fPIC` makes it possible to build coz against a normal installed version of libelfin. I'd eventually like to make a debian package from libelfin, which a coz debian package would depend on.