### PR TITLE
Fix installed pkg-configs

### DIFF
--- a/dwarf/Makefile
+++ b/dwarf/Makefile
@@ -50,7 +50,7 @@ install: libdwarf++.a libdwarf++.pc
 	install -t $(PREFIX)/lib libdwarf++.a
 	install -d $(PREFIX)/include/libelfin/dwarf
 	install -t $(PREFIX)/include/libelfin/dwarf data.hh dwarf++.hh small_vector.hh
-	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L${prefix},&/lib,;s,-I${prefix},&/include,' libdwarf++.pc \
+	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L$${prefix},&/lib,;s,-I$${prefix},&/include,' libdwarf++.pc \
 		> $(PREFIX)/lib/pkgconfig/libdwarf++.pc
 
 clean:

--- a/elf/Makefile
+++ b/elf/Makefile
@@ -48,7 +48,7 @@ install: libelf++.a libelf++.pc
 	install -t $(PREFIX)/lib libelf++.a
 	install -d $(PREFIX)/include/libelfin/elf
 	install -t $(PREFIX)/include/libelfin/elf common.hh data.hh elf++.hh
-	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L${prefix},&/lib,;s,-I${prefix},&/include,' libelf++.pc \
+	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L$${prefix},&/lib,;s,-I$${prefix},&/include,' libelf++.pc \
 		> $(PREFIX)/lib/pkgconfig/libelf++.pc
 
 clean:


### PR DESCRIPTION
Commit 2239556 patched the pkg-config files during installation, but
forgot to escape references to the prefix variable.