### PR TITLE
Fix installed pkg-configs

### DIFF
--- a/dwarf/Makefile
+++ b/dwarf/Makefile
@@ -32,13 +32,15 @@ CLEAN += to_string.cc
 # transformed in to the correct global pkg-config by install.
 libdwarf++.pc: always
 	@(VER=$$(git describe --match 'v*' | sed -e s/^v//); \
-	  echo "prefix=$$PWD"; \
+	  echo "libdir=$$PWD"; \
+	  echo "includedir=$$PWD"; \
+	  echo ""; \
 	  echo "Name: libdwarf++"; \
 	  echo "Description: C++11 DWARF library"; \
 	  echo "Version: $$VER"; \
 	  echo "Requires: libelf++ = $$VER"; \
-	  echo "Libs: -L\$${prefix} -ldwarf++"; \
-	  echo "Cflags: -I\$${prefix}") > $@
+	  echo "Libs: -L\$${libdir} -ldwarf++"; \
+	  echo "Cflags: -I\$${includedir}") > $@
 CLEAN += libdwarf++.pc
 
 .PHONY: always
@@ -50,7 +52,7 @@ install: libdwarf++.a libdwarf++.pc
 	install -t $(PREFIX)/lib libdwarf++.a
 	install -d $(PREFIX)/include/libelfin/dwarf
 	install -t $(PREFIX)/include/libelfin/dwarf data.hh dwarf++.hh small_vector.hh
-	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L${prefix},&/lib,;s,-I${prefix},&/include,' libdwarf++.pc \
+	sed 's,^libdir=.*,libdir=$(PREFIX)/lib,;s,^includedir=.*,includedir=$(PREFIX)/include,' libdwarf++.pc \
 		> $(PREFIX)/lib/pkgconfig/libdwarf++.pc
 
 clean:

--- a/elf/Makefile
+++ b/elf/Makefile
@@ -31,12 +31,14 @@ CLEAN += to_string.cc
 # transformed in to the correct global pkg-config by install.
 libelf++.pc: always
 	@(VER=$$(git describe --match 'v*' | sed -e s/^v//); \
-	  echo "prefix=$$PWD"; \
+	  echo "libdir=$$PWD"; \
+	  echo "includedir=$$PWD"; \
+	  echo ""; \
 	  echo "Name: libelf++"; \
 	  echo "Description: C++11 ELF library"; \
 	  echo "Version: $$VER"; \
-	  echo "Libs: -L\$${prefix} -lelf++"; \
-	  echo "Cflags: -I\$${prefix}") > $@
+	  echo "Libs: -L\$${libdir} -lelf++"; \
+	  echo "Cflags: -I\$${includedir}") > $@
 CLEAN += libelf++.pc
 
 .PHONY: always
@@ -48,7 +50,7 @@ install: libelf++.a libelf++.pc
 	install -t $(PREFIX)/lib libelf++.a
 	install -d $(PREFIX)/include/libelfin/elf
 	install -t $(PREFIX)/include/libelfin/elf common.hh data.hh elf++.hh
-	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L${prefix},&/lib,;s,-I${prefix},&/include,' libelf++.pc \
+	sed 's,^libdir=.*,libdir=$(PREFIX)/lib,;s,^includedir=.*,includedir=$(PREFIX)/include,' libelf++.pc \
 		> $(PREFIX)/lib/pkgconfig/libelf++.pc
 
 clean:


### PR DESCRIPTION
Commit 2239556 patched the pkg-config files during installation, but
forgot to escape references to the prefix variable. The result is that the
prefix substitution in upstream generates "/lib/new/prefix" instead of
"/new/prefix/lib".

Instead, use "libdir" and "includedir" variables in the pkgconfig file,
which are easier to patch during install.