### PR TITLE
Add support for dynamic linking with libelf++ and libdwarf++

### DIFF
--- a/dwarf/.gitignore
+++ b/dwarf/.gitignore
@@ -1,5 +1,7 @@
 *.o
 to_string.cc
 libdwarf++.a
+libdwarf++.so
+libdwarf++.so.*
 libdwarf++.pc
 /doc/

--- a/dwarf/Makefile
+++ b/dwarf/Makefile
@@ -1,7 +1,11 @@
+# Changed when ABI backwards compatibility is broken.
+# Typically uses the major version.
+SONAME = 0
+
 CXXFLAGS+=-g -O2 -Werror
 override CXXFLAGS+=-std=c++0x -Wall -fPIC
 
-all: libdwarf++.a libdwarf++.pc
+all: libdwarf++.a libdwarf++.so.$(SONAME) libdwarf++.so libdwarf++.pc
 
 SRCS := dwarf.cc cursor.cc die.cc value.cc abbrev.cc \
 	expr.cc rangelist.cc line.cc attrs.cc \
@@ -28,6 +32,14 @@ to_string.cc: ../elf/enum-print.py dwarf++.hh data.hh Makefile
 	@echo 'DWARFPP_END_NAMESPACE' >> to_string.cc
 CLEAN += to_string.cc
 
+libdwarf++.so.$(SONAME): $(SRCS:.cc=.o)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -Wl,-soname,$@ -o $@ $^
+CLEAN += libdwarf++.so.*
+
+libdwarf++.so:
+	ln -s $@.$(SONAME) $@
+CLEAN += libdwarf++.so
+
 # Create pkg-config for local library and headers. This will be
 # transformed in to the correct global pkg-config by install.
 libdwarf++.pc: always
@@ -45,9 +57,11 @@ CLEAN += libdwarf++.pc
 
 PREFIX?=/usr/local
 
-install: libdwarf++.a libdwarf++.pc
+install: libdwarf++.a libdwarf++.so.$(SONAME) libdwarf++.so libdwarf++.pc
 	install -d $(PREFIX)/lib/pkgconfig
 	install -t $(PREFIX)/lib libdwarf++.a
+	install -t $(PREFIX)/lib libdwarf++.so.$(SONAME)
+	install -t $(PREFIX)/lib libdwarf++.so
 	install -d $(PREFIX)/include/libelfin/dwarf
 	install -t $(PREFIX)/include/libelfin/dwarf data.hh dwarf++.hh small_vector.hh
 	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L${prefix},&/lib,;s,-I${prefix},&/include,' libdwarf++.pc \

--- a/elf/.gitignore
+++ b/elf/.gitignore
@@ -1,4 +1,6 @@
 *.o
 to_string.cc
 libelf++.a
+libelf++.so
+libelf++.so.*
 libelf++.pc

--- a/elf/Makefile
+++ b/elf/Makefile
@@ -1,7 +1,11 @@
+# Changed when ABI backwards compatibility is broken.
+# Typically uses the major version.
+SONAME = 0
+
 CXXFLAGS+=-g -O2 -Werror
 override CXXFLAGS+=-std=c++0x -Wall -fPIC
 
-all: libelf++.a libelf++.pc
+all: libelf++.a libelf++.so libelf++.so.$(SONAME) libelf++.pc
 
 SRCS := elf.cc mmap_loader.cc to_string.cc
 HDRS := elf++.hh data.hh common.hh to_hex.hh
@@ -27,6 +31,14 @@ to_string.cc: enum-print.py data.hh Makefile
 	@echo 'ELFPP_END_NAMESPACE' >> to_string.cc
 CLEAN += to_string.cc
 
+libelf++.so.$(SONAME): $(SRCS:.cc=.o)
+	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared -Wl,-soname,$@ -o $@ $^
+CLEAN += libelf++.so.*
+
+libelf++.so:
+	ln -s $@.$(SONAME) $@
+CLEAN += libelf++.so
+
 # Create pkg-config for local library and headers. This will be
 # transformed in to the correct global pkg-config by install.
 libelf++.pc: always
@@ -43,9 +55,11 @@ CLEAN += libelf++.pc
 
 PREFIX?=/usr/local
 
-install: libelf++.a libelf++.pc
+install: libelf++.a libelf++.so libelf++.so.$(SONAME) libelf++.pc
 	install -d $(PREFIX)/lib/pkgconfig
 	install -t $(PREFIX)/lib libelf++.a
+	install -t $(PREFIX)/lib libelf++.so.$(SONAME)
+	install -t $(PREFIX)/lib libelf++.so
 	install -d $(PREFIX)/include/libelfin/elf
 	install -t $(PREFIX)/include/libelfin/elf common.hh data.hh elf++.hh
 	sed 's,^prefix=.*,prefix=$(PREFIX),;s,-L${prefix},&/lib,;s,-I${prefix},&/include,' libelf++.pc \


### PR DESCRIPTION
Allows external projects to be compiled independently of changes to our
libraries, as long as they maintain ABI compatibility.

The ABI version is specified in the ABI variable of each library's
Makefile.