### PR TITLE
Don't mandate that compilation units need a DW_AT_comp_dir

### DIFF
--- a/dwarf/dwarf.cc
+++ b/dwarf/dwarf.cc
@@ -289,8 +289,7 @@ compilation_unit::get_line_table() const
 {
         if (!m->lt.valid()) {
                 const die &d = root();
-                if (!d.has(DW_AT::stmt_list) || !d.has(DW_AT::name) ||
-                    !d.has(DW_AT::comp_dir))
+                if (!d.has(DW_AT::stmt_list) || !d.has(DW_AT::name))
                         goto done;
 
                 shared_ptr<section> sec;
@@ -300,8 +299,10 @@ compilation_unit::get_line_table() const
                         goto done;
                 }
 
+                auto comp_dir = d.has(DW_AT::comp_dir) ? at_comp_dir(d) : "";
+                
                 m->lt = line_table(sec, d[DW_AT::stmt_list].as_sec_offset(),
-                                   m->subsec->addr_size, at_comp_dir(d),
+                                   m->subsec->addr_size, comp_dir,
                                    at_name(d));
         }
 done:


### PR DESCRIPTION
`dwarf::compilation_unit::get_line_table` silently exits if the compilation unit does not have a `DW_AT_comp_dir` attribute due to this check: https://github.com/aclements/libelfin/blob/master/dwarf/dwarf.cc#L293

This causes line table parsing to fail in some cases when invoking GCC with absolute paths.

Minimal example:

min.cpp:
`int main(){}`

    g++ -g min.cpp

Produces the following `DW_TAG_compile_unit` DIE, which does have a `DW_AT_comp_dir`:
```
COMPILE_UNIT<header overall offset = 0x00000000>:
< 0><0x0000000b>  DW_TAG_compile_unit
                    DW_AT_producer              GNU C++14 6.3.1 20170109 -mtune=generic -march=x86-64 -g
                    DW_AT_language              DW_LANG_C_plus_plus
                    DW_AT_name                  min.cpp
                    DW_AT_comp_dir              /home/simon/play/MiniDbg/examples
                    DW_AT_low_pc                0x004004c6
                    DW_AT_high_pc               <offset-from-lowpc>11
                    DW_AT_stmt_list             0x00000000
```

    g++ -g /path/to/min.cpp

Produces this, which does *not* have a `DW_AT_comp_dir`, but should still be allowed due to the absolute file name in `DW_AT_name`:

```
COMPILE_UNIT<header overall offset = 0x00000000>:
< 0><0x0000000b>  DW_TAG_compile_unit
                    DW_AT_producer              GNU C++14 6.3.1 20170109 -mtune=generic -march=x86-64 -g
                    DW_AT_language              DW_LANG_C_plus_plus
                    DW_AT_name                  /home/simon/play/MiniDbg/examples/min.cpp
                    DW_AT_low_pc                0x004004c6
                    DW_AT_high_pc               <offset-from-lowpc>11
                    DW_AT_stmt_list             0x00000000
```

With g++ version 6.3.1.
