### PR TITLE
Fix line_table::find_address when the address is the last entry

### DIFF
--- a/dwarf/line.cc
+++ b/dwarf/line.cc
@@ -174,6 +174,8 @@ line_table::find_address(taddr addr) const
                     !prev->end_sequence)
                         return prev;
         }
+        if (prev->address == addr && !prev->end_sequence)
+          return prev;
         prev = e;
         return prev;
 }


### PR DESCRIPTION
If this extra check is missing, in case the last valid entry in the line table matches the given address, `end` will still be returned.