### PR TITLE
Add guard for arguments.size() == 0 to evaluate

### DIFF
--- a/dwarf/expr.cc
+++ b/dwarf/expr.cc
@@ -41,9 +41,12 @@ expr::evaluate(expr_context *ctx, const std::initializer_list<taddr> &arguments)
         // Create the initial stack.  arguments are in reverse order
         // (that is, element 0 is TOS), so reverse it.
         stack.reserve(arguments.size());
-        for (const taddr *elt = arguments.end() - 1;
-             elt >= arguments.begin(); elt--)
-                stack.push_back(*elt);
+        if (arguments.size() > 0)
+        {
+          for (const taddr *elt = arguments.end() - 1;
+               elt >= arguments.begin(); elt--)
+                  stack.push_back(*elt);
+        }
 
         // Create a subsection for just this expression so we can
         // easily detect the end (including premature end).

--- a/dwarf/expr.cc
+++ b/dwarf/expr.cc
@@ -41,12 +41,8 @@ expr::evaluate(expr_context *ctx, const std::initializer_list<taddr> &arguments)
         // Create the initial stack.  arguments are in reverse order
         // (that is, element 0 is TOS), so reverse it.
         stack.reserve(arguments.size());
-        if (arguments.size() > 0)
-        {
-          for (const taddr *elt = arguments.end() - 1;
-               elt >= arguments.begin(); elt--)
-                  stack.push_back(*elt);
-        }
+        for (int i = arguments.size() - 1; i >= 0; i--)
+                stack.push_back(arguments[i]);
 
         // Create a subsection for just this expression so we can
         // easily detect the end (including premature end).


### PR DESCRIPTION
I ran into a segfault when calling `dwarf::expr::evaluate`. I took a look at the code and the issue seemed to be a fairly straightforward in that when `arguments` is empty, `end() == begin()` and so `end() - 1` is out of bounds. I believe [using an iterator pointing before `begin()` is UB](https://stackoverflow.com/questions/18225651/is-stdvectorbegin-1-undefined#18225695). I imagine we have different implementations on our systems so it didn't trigger before. Anyway, fix is simple.