### PR TITLE
fix data initialization of elf segment

### DIFF
--- a/elf/elf.cc
+++ b/elf/elf.cc
@@ -167,12 +167,10 @@ elf::get_segment(unsigned index) const
 
 struct segment::impl {
         impl(const elf &f)
-                : f(f) { }
+                : f(f), data(nullptr) { }
 
         const elf f;
         Phdr<> hdr;
-        //  const char *name;
-        //  size_t name_len;
         const void *data;
 };
 


### PR DESCRIPTION
Method segment::data depends on proper initialization of data field.
Also this commit deletes commented code.