### PR TITLE
ignore dwarf extensions of gcc in the line table

### DIFF
--- a/dwarf/abbrev.cc
+++ b/dwarf/abbrev.cc
@@ -133,6 +133,10 @@ resolve_type(DW_AT name, DW_FORM form)
                 case DW_AT::ranges:
                         return value::type::rangelist;
 
+                case DW_AT::lo_user...DW_AT::hi_user:
+                        //HACK: ignore vendor extensions
+                        return value::type::invalid;
+
                 default:
                         throw format_error("DW_FORM_sec_offset not expected for attribute " +
                                            to_string(name));


### PR DESCRIPTION
gcc 9 uses DWARF 4 by default with vendor extensions in the line table which
results in a thrown exception. An application using libelfin cannot recover
from an exception and still get a reasonable line table. Now, when a vendor
extension is encountered, the type is set to invalid to get around the issue.

Fixes https://github.com/aclements/libelfin/issues/39 for me.