### PR TITLE
Add DESTDIR support

### DIFF
--- a/dwarf/Makefile
+++ b/dwarf/Makefile
@@ -60,14 +60,14 @@ CLEAN += libdwarf++.pc
 PREFIX?=/usr/local
 
 install: libdwarf++.a libdwarf++.so.$(SONAME) libdwarf++.so libdwarf++.pc
-	install -d $(PREFIX)/lib/pkgconfig
-	install -t $(PREFIX)/lib libdwarf++.a
-	install -t $(PREFIX)/lib libdwarf++.so.$(SONAME)
-	install -t $(PREFIX)/lib libdwarf++.so
-	install -d $(PREFIX)/include/libelfin/dwarf
-	install -t $(PREFIX)/include/libelfin/dwarf data.hh dwarf++.hh small_vector.hh
+	install -d $(DESTDIR)$(PREFIX)/lib/pkgconfig
+	install -t $(DESTDIR)$(PREFIX)/lib libdwarf++.a
+	install -t $(DESTDIR)$(PREFIX)/lib libdwarf++.so.$(SONAME)
+	install -t $(DESTDIR)$(PREFIX)/lib libdwarf++.so
+	install -d $(DESTDIR)$(PREFIX)/include/libelfin/dwarf
+	install -t $(DESTDIR)$(PREFIX)/include/libelfin/dwarf data.hh dwarf++.hh small_vector.hh
 	sed 's,^libdir=.*,libdir=$(PREFIX)/lib,;s,^includedir=.*,includedir=$(PREFIX)/include,' libdwarf++.pc \
-		> $(PREFIX)/lib/pkgconfig/libdwarf++.pc
+		> $(DESTDIR)$(PREFIX)/lib/pkgconfig/libdwarf++.pc
 
 clean:
 	rm -f $(CLEAN)

--- a/elf/Makefile
+++ b/elf/Makefile
@@ -58,14 +58,14 @@ CLEAN += libelf++.pc
 PREFIX?=/usr/local
 
 install: libelf++.a libelf++.so libelf++.so.$(SONAME) libelf++.pc
-	install -d $(PREFIX)/lib/pkgconfig
-	install -t $(PREFIX)/lib libelf++.a
-	install -t $(PREFIX)/lib libelf++.so.$(SONAME)
-	install -t $(PREFIX)/lib libelf++.so
-	install -d $(PREFIX)/include/libelfin/elf
-	install -t $(PREFIX)/include/libelfin/elf common.hh data.hh elf++.hh
+	install -d $(DESTDIR)$(PREFIX)/lib/pkgconfig
+	install -t $(DESTDIR)$(PREFIX)/lib libelf++.a
+	install -t $(DESTDIR)$(PREFIX)/lib libelf++.so.$(SONAME)
+	install -t $(DESTDIR)$(PREFIX)/lib libelf++.so
+	install -d $(DESTDIR)$(PREFIX)/include/libelfin/elf
+	install -t $(DESTDIR)$(PREFIX)/include/libelfin/elf common.hh data.hh elf++.hh
 	sed 's,^libdir=.*,libdir=$(PREFIX)/lib,;s,^includedir=.*,includedir=$(PREFIX)/include,' libelf++.pc \
-		> $(PREFIX)/lib/pkgconfig/libelf++.pc
+		> $(DESTDIR)$(PREFIX)/lib/pkgconfig/libelf++.pc
 
 clean:
 	rm -f $(CLEAN)


### PR DESCRIPTION
For packaging it is useful to be able to install to a custom temporary installation location. The existing `PREFIX` variable is not enough for this purpose because it will lead to incorrect pkg-config files (e.g. setting `PREFIX="$pkgdir/usr"` leads to `includedir=$pkgdir/usr/include` while it should be `includedir=/usr/include` instead). `DESTDIR` is the standard name for this variable, defined by the [GNU coding standards](https://www.gnu.org/prep/standards/html_node/DESTDIR.html).

Fixes: #35
Also see: Arch Linux [FS#64881](https://bugs.archlinux.org/task/64881)