### PR TITLE
Remove const qualifier from setter

### DIFF
--- a/elf/data.hh
+++ b/elf/data.hh
@@ -553,7 +553,7 @@ struct Sym<Elf64, Order>
                 return (stb)(info >> 4);
         }
 
-        void set_binding(stb v) const
+        void set_binding(stb v)
         {
                 info = (info & 0xF) | ((unsigned char)v << 4);
         }


### PR DESCRIPTION
This is just a typo fix. Fixes #44 

clang-10 refuses to compile library:

```
.../libelfin/elf/data.hh:558:22: error: cannot assign to non-static data member within const member function 'set_binding'
                info = (info & 0xF) | ((unsigned char)v << 4);
                ~~~~ ^
.../libelfin/elf/data.hh:556:14: note: member function 'elf::Sym<elf::Elf64, Order>::set_binding' is declared const here
        void set_binding(stb v) const
        ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
``` 