### PR TITLE
Add support for architecture ppc64le.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 sudo: required
 # The default environment is Ubuntu 12.04, which only has GCC 4.6.
 dist: trusty


### PR DESCRIPTION
Add architecture ppc64le to travis build
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
