### PR TITLE
Clang warnings

### DIFF
--- a/elf/data.hh
+++ b/elf/data.hh
@@ -553,7 +553,7 @@ struct Sym<Elf64, Order>
                 return (stb)(info >> 4);
         }
 
-        void set_binding(stb v) const
+        void set_binding(stb v)
         {
                 info = (info & 0xF) | ((unsigned char)v << 4);
         }

--- a/elf/elf++.hh
+++ b/elf/elf++.hh
@@ -423,12 +423,12 @@ public:
                         return *this;
                 }
 
-                bool operator==(iterator &o) const
+                bool operator==(const iterator &o) const
                 {
                         return pos == o.pos;
                 }
 
-                bool operator!=(iterator &o) const
+                bool operator!=(const iterator &o) const
                 {
                         return pos != o.pos;
                 }


### PR DESCRIPTION
Fixes build warnings under recent clang:
-  Sym<>::set_binding is not const and should not be marked as such.
-  C++20 considers the definitions of symtab::iterator::operator==/!= to be ambiguous because they are non-symmetrical (const on this, but not on the argument).