### PR TITLE
fix cursor.cc reading an empty string error when compile without "-o2…

### DIFF
--- a/dwarf/cursor.cc
+++ b/dwarf/cursor.cc
@@ -86,7 +86,9 @@ cursor::string(std::string &out)
         size_t size;
         const char *p = this->cstr(&size);
         out.resize(size);
-        memmove(&out.front(), p, size);
+		if (size > 0) {
+			memmove(&out.front(), p, size);
+		}
 }
 
 const char *


### PR DESCRIPTION
fix cursor.cc reading an empty string error when compile without "-o2…

```
void
cursor::string(std::string &out)
{
        size_t size;
        const char *p = this->cstr(&size);
        out.resize(size);
	if (size > 0)
	{
        	memmove(&out.front(), p, size);
	}
}
```
without -o2,  "memmove(&out.front(), p, 0) will raise an assert error in gcc8.1.4 centos 8.5(4.18.0-348.2.1.el8_5.x86_64)"