### PR TITLE
Updated with patches from antoyo and suggested changes from aclements.

### DIFF
--- a/dwarf/cursor.cc
+++ b/dwarf/cursor.cc
@@ -67,6 +67,12 @@ cursor::skip_initial_length()
         }
 }
 
+void
+cursor::skip_unit_type()
+{
+    pos += sizeof(sbyte);
+}
+
 section_offset
 cursor::offset()
 {

--- a/dwarf/dwarf.cc
+++ b/dwarf/dwarf.cc
@@ -273,12 +273,23 @@ compilation_unit::compilation_unit(const dwarf &file, section_offset offset)
         cursor sub(subsec);
         sub.skip_initial_length();
         uhalf version = sub.fixed<uhalf>();
-        if (version < 2 || version > 4)
+        (void)version;
+        if (version > 5)
                 throw format_error("unknown compilation unit version " + std::to_string(version));
         // .debug_abbrev-relative offset of this unit's abbrevs
-        section_offset debug_abbrev_offset = sub.offset();
-        ubyte address_size = sub.fixed<ubyte>();
-        subsec->addr_size = address_size;
+        section_offset debug_abbrev_offset;
+        if(version >= 5)
+        {
+            sub.skip_unit_type();
+            ubyte address_size = sub.fixed<ubyte>();
+            subsec->addr_size = address_size;
+            debug_abbrev_offset = sub.offset();
+        }
+        else {
+            debug_abbrev_offset = sub.offset();
+            ubyte address_size = sub.fixed<ubyte>();
+            subsec->addr_size = address_size;
+        }
 
         m = make_shared<impl>(file, offset, subsec, debug_abbrev_offset,
                               sub.get_section_offset());

--- a/dwarf/internal.hh
+++ b/dwarf/internal.hh
@@ -178,6 +178,7 @@ struct cursor
         }
 
         void skip_initial_length();
+        void skip_unit_type();
         void skip_form(DW_FORM form);
 
         cursor &operator+=(section_offset offset)

--- a/dwarf/line.cc
+++ b/dwarf/line.cc
@@ -84,7 +84,7 @@ line_table::line_table(const shared_ptr<section> &sec, section_offset offset,
         m->program_offset = cur.get_section_offset() + header_length;
         m->minimum_instruction_length = cur.fixed<ubyte>();
         m->maximum_operations_per_instruction = 1;
-        if (version == 4)
+        if (version >= 4)
                 m->maximum_operations_per_instruction = cur.fixed<ubyte>();
         if (m->maximum_operations_per_instruction == 0)
                 throw format_error("maximum_operations_per_instruction cannot"

--- a/elf/data.hh
+++ b/elf/data.hh
@@ -553,7 +553,7 @@ struct Sym<Elf64, Order>
                 return (stb)(info >> 4);
         }
 
-        void set_binding(stb v) const
+        void set_binding(stb v)
         {
                 info = (info & 0xF) | ((unsigned char)v << 4);
         }


### PR DESCRIPTION
Replaces https://github.com/aclements/libelfin/pull/69.
