### PR TITLE
don't use a VLA just to compute a buffer size

### DIFF
--- a/dwarf/small_vector.hh
+++ b/dwarf/small_vector.hh
@@ -93,7 +93,7 @@ public:
                 while (target < n)
                         target <<= 1;
 
-                char *newbuf = new char[sizeof(T[target])];
+                char *newbuf = new char[target * sizeof(T)];
                 T *src = base, *dest = (T*)newbuf;
                 for (; src < end; src++, dest++) {
                         new(dest) T(*src);


### PR DESCRIPTION
VLAs in C++ are compiler extensions, and clang 18 will complain about it.

Bug-Ubuntu: https://bugs.launchpad.net/ubuntu/+source/libelfin/+bug/2060786
Bug-Debian: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1065084