### PR TITLE
Fix memory leaks and string assert #34

### DIFF
--- a/dwarf/cursor.cc
+++ b/dwarf/cursor.cc
@@ -92,6 +92,7 @@ cursor::string(std::string &out)
         size_t size;
         const char *p = this->cstr(&size);
         out.resize(size);
+        if (size == 0) return;
         memmove(&out.front(), p, size);
 }
 

--- a/dwarf/dwarf.cc
+++ b/dwarf/dwarf.cc
@@ -254,7 +254,7 @@ unit::impl::force_abbrevs()
                 // Move the map into the vector
                 abbrevs_vec.resize(highest + 1);
                 for (auto &entry : abbrevs_map)
-                        abbrevs_vec[entry.first] = move(entry.second);
+                        abbrevs_vec[entry.first] = std::move(entry.second);
                 abbrevs_map.clear();
         }
 

--- a/dwarf/line.cc
+++ b/dwarf/line.cc
@@ -129,7 +129,7 @@ line_table::line_table(const shared_ptr<section> &sec, section_offset offset,
                 if (incdir.back() != '/')
                         incdir += '/';
                 if (incdir[0] == '/')
-                        m->include_directories.push_back(move(incdir));
+                        m->include_directories.push_back(std::move(incdir));
                 else
                         m->include_directories.push_back(comp_dir + incdir);
         }
@@ -218,7 +218,7 @@ line_table::impl::read_file_entry(cursor *cur, bool in_header)
         last_file_name_end = cur->get_section_offset();
 
         if (file_name[0] == '/')
-                file_names.emplace_back(move(file_name), mtime, length);
+                file_names.emplace_back(std::move(file_name), mtime, length);
         else if (dir_index < include_directories.size())
                 file_names.emplace_back(
                         include_directories[dir_index] + file_name,

--- a/elf/elf.cc
+++ b/elf/elf.cc
@@ -169,7 +169,7 @@ struct segment::impl {
         impl(const elf &f)
                 : f(f), data(nullptr) { }
 
-        const elf f;
+        const elf &f;
         Phdr<> hdr;
         const void *data;
 };
@@ -223,7 +223,7 @@ struct section::impl
         impl(const elf &f)
                 : f(f), name(nullptr), data(nullptr) { }
 
-        const elf f;
+        const elf &f;
         Shdr<> hdr;
         const char *name;
         size_t name_len;


### PR DESCRIPTION
This fixes 2 memory leaks and a string assert demonstrated in issue #34. Also I prepended `std::` to all the `move` calls. Please merge.